### PR TITLE
generate launch.json for vscode debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ clap = { version = "4.4.11", features = ["derive"] }
 indicatif = "0.17.7"
 open = "5.0.1"
 probe-rs = "0.24.0"
+serde_json = "1.0.122"
 termimad = "0.29.1"

--- a/src/cli/init_args.rs
+++ b/src/cli/init_args.rs
@@ -18,4 +18,11 @@ pub struct InitArgs {
 
     #[arg(long, help = "Configure for use with a Softdevice (NRF only).")]
     pub softdevice: Option<Softdevice>,
+
+    #[arg(
+        long,
+        help = "Generate config files for vscode.",
+        default_value_t = false
+    )]
+    pub vscode: bool,
 }

--- a/src/templates/launch.json.template
+++ b/src/templates/launch.json.template
@@ -1,0 +1,44 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "probe-rs-debug",
+      "request": "launch",
+      "name": "probe_rs",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "probe-rs",
+      "runtimeArgs": ["dap-server"],
+      "chip": "chip_name",
+      "flashingConfig": {
+        "flashingEnabled": true,
+        "haltAfterReset": false,
+        "formatOptions": {
+        }
+      },
+      "coreConfigs": [
+        {
+          "coreIndex": 0,
+          "rttEnabled": true,
+          "rttChannelFormats": [
+            {
+              "channelNumber": 0,
+              "dataFormat": "String",
+              "showTimestamps": true
+            },
+            {
+              "channelNumber": 1,
+              "dataFormat": "BinaryLE"
+            }
+          ],
+          "programBinary": "path_to_your_binary",
+          "svdFile": "" 
+        }
+      ],
+      "env": {
+        "RUST_LOG": "info"
+      },
+      "consoleLogLevel": "Console"
+    }
+  ]
+}
+


### PR DESCRIPTION
Users can use probe-rs debug through vscode.
This patch can generate a proper launch.json based on chipname.