### PR TITLE
add missing 'f' for debug macro in fmt.rs

### DIFF
--- a/src/templates/fmt.rs.template
+++ b/src/templates/fmt.rs.template
@@ -118,7 +118,7 @@ macro_rules! debug {
         {
             #[cfg(feature = "defmt")]
             ::defmt::debug!($s $(, $x)*);
-            #[cfg(not(eature="defmt"))]
+            #[cfg(not(feature="defmt"))]
             let _ = ($( & $x ),*);
         }
     };


### PR DESCRIPTION
This fixes the `debug` macro in `fmt.rs`