### PR TITLE
Added automatically generated file comment to `fmt.rs.template`.

### DIFF
--- a/src/templates/fmt.rs.template
+++ b/src/templates/fmt.rs.template
@@ -1,3 +1,5 @@
+// This file was automatically generated.
+
 #![allow(unused)]
 
 macro_rules! assert {


### PR DESCRIPTION
`fmt.rs.template` was missing the "automatically generated file" comment. I added it :) 

- Simon 🦫 