### PR TITLE
Clippy needless lifetime fmt.rs change.

### DIFF
--- a/src/templates/fmt.rs.template
+++ b/src/templates/fmt.rs.template
@@ -216,7 +216,7 @@ impl<T, E> Try for Result<T, E> {
 pub(crate) struct Bytes<'a>(pub &'a [u8]);
 
 #[cfg(feature = "defmt")]
-impl<'a> defmt::Format for Bytes<'a> {
+impl defmt::Format for Bytes<'_> {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(fmt, "{:02x}", self.0)
     }


### PR DESCRIPTION
```
warning: the following explicit lifetimes could be elided: 'a
   --> src\fmt.rs:221:6
    |
221 | impl<'a> defmt::Format for Bytes<'a> {
    |      ^^                          ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
221 - impl<'a> defmt::Format for Bytes<'a> {
221 + impl defmt::Format for Bytes<'_> {
```

🦫 